### PR TITLE
Replace `os.tmpDir()` by `os.tmpdir()`

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,7 @@ Lambda.prototype.deploy = function( program ) {
 
 	var _this = this
 	var lambda = new aws.Lambda( { apiVersion: "2014-11-11" } )
-	var tmpfile = path.join( os.tmpDir(), $config.FunctionName + "-" + new Date().getTime() + ".zip" )
+	var tmpfile = path.join( os.tmpdir(), $config.FunctionName + "-" + new Date().getTime() + ".zip" )
 	var $configPath = program.split('/').slice(0,-1).join('/')
 	//console.log( $configPath )
 


### PR DESCRIPTION
Avoid warning "os.tmpDir() is deprecated. Use os.tmpdir() instead."