### PR TITLE
Zip only files from package.json

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -59,7 +59,21 @@ Lambda.prototype.deploy = function( program ) {
 	var $cwd = process.cwd()
 	process.chdir($fullFunctionPath)
 
-	var $zipCmd = "zip -r -9  " + tmpfile + ' .'
+	var zipfileList = '.'
+
+	try {
+		var packageJson = fs.readFileSync( 'package.json', 'utf8' )
+
+		if ( packageJson ) {
+			var packageJsonFiles = JSON.parse( packageJson ).files
+
+			if ( typeof packageJsonFiles === 'object' ) {
+				var zipfileList = packageJsonFiles.join( ' ' )
+			}
+		}
+	} catch (e) { }
+
+	var $zipCmd = "zip -r -9  " + tmpfile + ' ' + zipfileList
 
 	exec( $zipCmd, { maxBuffer: 1024 * 1024 } ,function( err, stdout, stderr ) {
 		process.chdir($cwd)


### PR DESCRIPTION
Reduce ZIP size and transfer time by compressing only package related files, see https://docs.npmjs.com/files/package.json#files